### PR TITLE
Fix ghc Monoid/Semigroup Issue for cabal-based builds with newer versions of base

### DIFF
--- a/Graphics/OpenSCAD.hs
+++ b/Graphics/OpenSCAD.hs
@@ -619,13 +619,13 @@ diam :: Double -> Double
 diam = (/ 2)
 
 -- Now, let Haskell work it's magic
+instance Vector v => Semigroup (Model v) where
+  (Solid (Box 0 0 0)) <> b                   = b
+  a                   <> (Solid (Box 0 0 0)) = a
+  a                   <> b                   = union [a, b]
+
 instance Vector v => Monoid (Model v) where
   mempty = Solid $ Box 0 0 0
-  mappend (Solid (Box 0 0 0)) b = b
-  mappend a (Solid (Box 0 0 0)) = a
-  mappend a b = union [a, b]
-  mconcat [a] = a
-  mconcat as = union as
 
 
 -- | You can use '(#)' to write transformations in a more readable postfix form,


### PR DESCRIPTION
I'm playing around with this package in a project that generates OpenSCAD geometries from Haskell. I found that when running `cabal v2-build` on a project which includes this package, ghc pukes:
```haskell
Graphics/OpenSCAD.hs:622:10: error:
    • Could not deduce (Semigroup (Model v))
        arising from the superclasses of an instance declaration
      from the context: Vector v
        bound by the instance declaration at Graphics/OpenSCAD.hs:622:10-37
    • In the instance declaration for ‘Monoid (Model v)’
    |
622 | instance Vector v => Monoid (Model v) where
    |   
```

Looks like the Monoid instance in `OpenSCAD.hs` predates the split in `base` from a single Monoid typeclass (base < 4.11) which has both `mappend` and `mempty` to separate Monoid and Semigroup classes (base >=4.11) for these two functions. Currently, cabal selects base-4.12.0.0, given the constraints in `OpenSCAD.cabal`.

I was able to fix this for my project by defining separate Semigroup and Monoid instances for Model in 8405259. This could probably also be fixed by constraining base < 4.11 in `OpenSCAD.cabal`.